### PR TITLE
🧑‍💻 Add new AsyncTaskBuilder to merge fetch and submit usage

### DIFF
--- a/example/lib/news_reader/news_reader.page.dart
+++ b/example/lib/news_reader/news_reader.page.dart
@@ -18,98 +18,96 @@ class _NewsReaderPageState extends State<NewsReaderPage> with BlocProvider<NewsR
 
   @override
   Widget build(BuildContext context) {
-    return SubmitBuilder<ArticleVote>(
-      task: bloc.voteArticle,
-      onSuccess: (vote) {
-        // Display a success message
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text('Voted successfully: ${vote.name}'),
-          backgroundColor: Colors.green,
-        ));
+    return AsyncTaskBuilder<void, ArticleVote>.submit(
+        task: bloc.voteArticle,
+        onSuccess: (vote) {
+          // Display a success message
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text('Voted successfully: ${vote.name}'),
+            backgroundColor: Colors.green,
+          ));
 
-        // Navigate to the next page
-        Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => NewsReaderPage(page: widget.page + 1)));
-      },
-      builder: (context, runTask) {
-        return Scaffold(
-          appBar: AppBar(
-            title: Text('News reader #${widget.page}'),
-          ),
-          body: FetchBuilder<NewsArticle>(
-            task: bloc.fetchArticle,
-            config: FetcherConfig(
-              fetchingBuilder: (context) => Padding(
-                padding: const EdgeInsets.all(20),
-                child: Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    children: [
-                      const CircularProgressIndicator(),
-                      const SizedBox(height: 10),
-                      Text('Fetching article ${widget.page}...'),
-                    ],
+          // Navigate to the next page
+          Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => NewsReaderPage(page: widget.page + 1)));
+        },
+        builder: (context, runTask) {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text('News reader #${widget.page}'),
+            ),
+            body: AsyncTaskBuilder.basic<NewsArticle>(
+                task: bloc.fetchArticle,
+                config: FetcherConfig(
+                  fetchingBuilder: (context) => Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        children: [
+                          const CircularProgressIndicator(),
+                          const SizedBox(height: 10),
+                          Text('Fetching article ${widget.page}...'),
+                        ],
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ),
-            builder: (context, article) {
-              return Padding(
-                padding: const EdgeInsets.all(20),
-                child: Column(
-                  children: [
-                    // Title
-                    Text(
-                      article.title,
-                      style: Theme.of(context).textTheme.headlineSmall,
-                    ),
+                builder: (context, article) {
+                  return Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      children: [
+                        // Title
+                        Text(
+                          article.title,
+                          style: Theme.of(context).textTheme.headlineSmall,
+                        ),
 
-                    // Content
-                    const SizedBox(height: 15),
-                    Text(
-                      article.content,
-                      style: Theme.of(context).textTheme.bodyLarge,
-                    ),
+                        // Content
+                        const SizedBox(height: 15),
+                        Text(
+                          article.content,
+                          style: Theme.of(context).textTheme.bodyLarge,
+                        ),
 
-                    // Vote buttons
-                    const Spacer(),
-                    const SizedBox(height: 15),
-                    DataStreamBuilder<ArticleVote?>(
-                      stream: bloc.selectedVote,
-                      builder: (context, selectedVote) {
-                        return ToggleButtons(
-                          isSelected: [
-                            selectedVote == ArticleVote.like,
-                            selectedVote == ArticleVote.dislike,
-                          ],
-                          onPressed: (index) => bloc.selectVote(index == 0 ? ArticleVote.like : ArticleVote.dislike),
-                          children: const [
-                            Icon(Icons.thumb_up),
-                            Icon(Icons.thumb_down),
-                          ],
-                        );
-                      },
-                    ),
+                        // Vote buttons
+                        const Spacer(),
+                        const SizedBox(height: 15),
+                        DataStreamBuilder<ArticleVote?>(
+                          stream: bloc.selectedVote,
+                          builder: (context, selectedVote) {
+                            return ToggleButtons(
+                              isSelected: [
+                                selectedVote == ArticleVote.like,
+                                selectedVote == ArticleVote.dislike,
+                              ],
+                              onPressed: (index) => bloc.selectVote(index == 0 ? ArticleVote.like : ArticleVote.dislike),
+                              children: const [
+                                Icon(Icons.thumb_up),
+                                Icon(Icons.thumb_down),
+                              ],
+                            );
+                          },
+                        ),
 
-                    // Vote
-                    const SizedBox(height: 15),
-                    ElevatedButton(
-                      onPressed: runTask,
-                      child: const Text('Vote'),
-                    ),
+                        // Vote
+                        const SizedBox(height: 15),
+                        ElevatedButton(
+                          onPressed: runTask,
+                          child: const Text('Vote'),
+                        ),
 
-                    // Vote with error
-                    const SizedBox(height: 15),
-                    ElevatedButton(
-                      onPressed: () => runTask(bloc.voteArticleWithError),
-                      child: const Text('Vote with error'),
+                        // Vote with error
+                        const SizedBox(height: 15),
+                        ElevatedButton(
+                          onPressed: () => runTask(bloc.voteArticleWithError),
+                          child: const Text('Vote with error'),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-              );
-            }
-          ),
-        );
-      }
-    );
+                  );
+                }),
+          );
+        });
   }
 }

--- a/example/lib/widgets/pages/fetch_builder.page.dart
+++ b/example/lib/widgets/pages/fetch_builder.page.dart
@@ -11,14 +11,14 @@ class FetchBuilderPage extends StatefulWidget {
 }
 
 class _FetchBuilderPageState extends State<FetchBuilderPage> {
-  final _fetchController1 = FetchBuilderWithParameterController<bool, String>();
-  final _fetchController2 = FetchBuilderController<String>();
+  final _fetchController1 = AsyncTaskBuilderController<bool, String>();
+  final _fetchController2 = AsyncTaskBuilderController.basic<String>();
 
   bool withError = false;
   bool dataClear = false;
   FetchErrorDisplayMode errorDisplayMode = FetchErrorDisplayMode.values.first;
 
-  Future<String> fetchTask(bool? withError) async {
+  Future<String> fetchTask([bool? withError]) async {
     final response = await http.get(Uri.parse('http://worldtimeapi.org/api/timezone/Europe/Paris'));
     await Future.delayed(const Duration(seconds: 2));
     if (withError == true) throw Exception('Error !');
@@ -29,24 +29,24 @@ class _FetchBuilderPageState extends State<FetchBuilderPage> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-
         // Unmounted state test
         // Test error handling when state is unmounted
         ElevatedButton(
-          onPressed: () => Navigator.of(context).push(MaterialPageRoute(builder: (_) => Scaffold(
-            appBar: AppBar(
-              title: const Text('Unmounted state test'),
-            ),
-            body: FetchBuilder<Object>(
-              task: () async {
-                await Future.delayed(const Duration(milliseconds: 500)).then((value) {
-                  if(context.mounted) Navigator.of(context).pop();
-                });
-                await Future.delayed(const Duration(seconds: 2));
-                throw Exception('test');
-              },
-            ),
-          ))),
+          onPressed: () => Navigator.of(context).push(MaterialPageRoute(
+              builder: (_) => Scaffold(
+                    appBar: AppBar(
+                      title: const Text('Unmounted state test'),
+                    ),
+                    body: AsyncTaskBuilder.basic(
+                      task: () async {
+                        await Future.delayed(const Duration(milliseconds: 500)).then((value) {
+                          if (context.mounted) Navigator.of(context).pop();
+                        });
+                        await Future.delayed(const Duration(seconds: 2));
+                        throw Exception('test');
+                      },
+                    ),
+                  ))),
           child: const Text('Unmounted state test'),
         ),
 
@@ -95,12 +95,12 @@ class _FetchBuilderPageState extends State<FetchBuilderPage> {
 
         // Parameterized Fetcher
         Expanded(
-          child: FetchBuilderWithParameter<bool, String>(
+          child: AsyncTaskBuilder<bool, String>.fetch(
             controller: _fetchController1,
             task: fetchTask,
             config: const FetcherConfig(
               // fadeDuration: Duration.zero,    // Disable fade
-              fadeDuration: Duration(seconds: 1),   // Long fade
+              fadeDuration: Duration(seconds: 1), // Long fade
             ),
             builder: (context, data) {
               return Column(
@@ -128,7 +128,7 @@ class _FetchBuilderPageState extends State<FetchBuilderPage> {
           padding: EdgeInsets.all(10),
           child: _Title(title: 'Dense Fetcher with Error'),
         ),
-        FetchBuilder<String>(
+        AsyncTaskBuilder.basic<String>(
           task: () async => throw Exception('Error !!'),
           config: const FetcherConfig(
             isDense: true,
@@ -147,13 +147,14 @@ class _FetchBuilderPageState extends State<FetchBuilderPage> {
           child: const Text('Fetch'),
         ),
         const SizedBox(height: 20),
-        FetchBuilder<String>(
+        AsyncTaskBuilder.basic<String>(
           controller: _fetchController2,
           fetchAtInit: false,
           task: () => Future.delayed(const Duration(seconds: 2), () => 'success'),
-          onSuccess: (result) => Navigator.of(context).push(MaterialPageRoute(builder: (_) => Scaffold(
-            body: Center(child: Text(result)),
-          ))),
+          onSuccess: (result) => Navigator.of(context).push(MaterialPageRoute(
+              builder: (_) => Scaffold(
+                    body: Center(child: Text(result)),
+                  ))),
           initBuilder: (_) => const Text('Press Fetch to start'),
         ),
         const SizedBox(height: 20),

--- a/example/lib/widgets/pages/submit_builder.page.dart
+++ b/example/lib/widgets/pages/submit_builder.page.dart
@@ -18,7 +18,6 @@ class _SubmitBuilderPageState extends State<SubmitBuilderPage> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-
         // Settings
         CheckboxListTile(
           title: const Text('Run task on start'),
@@ -34,7 +33,7 @@ class _SubmitBuilderPageState extends State<SubmitBuilderPage> {
 
         // Classic SubmitBuilder
         Expanded(
-          child: SubmitBuilder<String>(
+          child: AsyncTaskBuilder<void, String>.submit(
             key: ValueKey(_refreshKey),
             runTaskOnStart: _runTaskOnStart,
             task: () => Future.delayed(const Duration(seconds: 2), () => 'success'),
@@ -47,7 +46,6 @@ class _SubmitBuilderPageState extends State<SubmitBuilderPage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 mainAxisSize: MainAxisSize.max,
                 children: [
-
                   // Basic run
                   Center(
                     child: ElevatedButton(
@@ -66,7 +64,6 @@ class _SubmitBuilderPageState extends State<SubmitBuilderPage> {
                       child: const Text('Press to start with error'),
                     ),
                   ),
-
                 ],
               );
             },
@@ -77,7 +74,7 @@ class _SubmitBuilderPageState extends State<SubmitBuilderPage> {
         const Separator(),
         Padding(
           padding: const EdgeInsets.all(20),
-          child: SubmitBuilder<void>(
+          child: AsyncTaskBuilder.submit(
             task: () => Future.delayed(const Duration(seconds: 3)),
             onSuccess: (_) => ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
               content: Text('Success !'),

--- a/lib/fetcher.dart
+++ b/lib/fetcher.dart
@@ -4,10 +4,9 @@ export 'src/config/default_fetcher_config.dart';
 export 'src/config/fetcher_config.dart';
 export 'src/exceptions/fetch_exception.dart';
 export 'src/models/fetch_error_data.dart';
+export 'src/async_task_builder.dart';
 
 export 'src/submit_form_builder.dart';
-export 'src/submit_builder.dart';
 export 'src/async_edit_builder.dart';
-export 'src/fetch_builder.dart';
 export 'src/event_fetch_builder.dart';
 export 'src/paged_list_view_fetcher.dart';

--- a/lib/src/async_edit_builder.dart
+++ b/lib/src/async_edit_builder.dart
@@ -50,21 +50,22 @@ class AsyncEditBuilder<T> extends StatefulWidget {
 }
 
 class _AsyncEditBuilderState<T> extends State<AsyncEditBuilder<T>> {
-  final _fetcherController = FetchBuilderWithParameterController<T, T>();
+  final _fetcherController = AsyncTaskBuilderController<T, T>();
   late final _fetchBuilderConfig = () {
     if (widget.fetchingBuilder == null) return widget.config;
     final fetchingBuilderConfig = FetcherConfig(fetchingBuilder: widget.fetchingBuilder);
     return widget.config == null ? fetchingBuilderConfig : widget.config!.apply(fetchingBuilderConfig);
-  } ();
+  }();
 
   @override
   Widget build(BuildContext context) {
-    return FetchBuilderWithParameter<T, T>(
+    return AsyncTaskBuilder<T, T>.fetchWithParameter(
       controller: _fetcherController,
       config: _fetchBuilderConfig,
       task: (value) async => value ?? await widget.fetchTask(),
       builder: (context, data) {
-        return SubmitBuilder<T>(
+        return AsyncTaskBuilder<void, T>.submit(
+          ///TODO: Find a way to make task optional here
           config: widget.config,
           onSuccess: (data) {
             widget.onEditSuccess?.call(data);

--- a/lib/src/async_task_builder.dart
+++ b/lib/src/async_task_builder.dart
@@ -1,0 +1,301 @@
+import 'package:fetcher/extra.dart';
+import 'package:fetcher/src/submit_builder.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:value_stream/value_stream.dart';
+
+import 'config/default_fetcher_config.dart';
+import 'config/fetcher_config.dart';
+import 'exceptions/fetch_exception.dart';
+import 'utils/data_wrapper.dart';
+import 'widgets/fetch_builder_content.dart';
+
+typedef TaskRunnerCallback<T> = void Function([AsyncValueGetter<T>? task]);
+
+enum AsyncTaskMode { fetch, fetchWithParameter, submit }
+
+enum FetchErrorDisplayMode { inWidget, onDisplay }
+
+class AsyncTaskBuilder<T, R> extends StatefulWidget {
+  final AsyncTaskMode mode;
+  final FetcherConfig? config;
+  final ParameterizedAsyncTask<T, R> task;
+  final bool fetchAtInit;
+  final WidgetBuilder? initBuilder;
+  final DataWidgetBuilder<R>? builder;
+  final ValueSetter<R>? onSuccess;
+  final ValueGetter<R?>? getFromCache;
+  final ValueChanged<R>? saveToCache;
+  final Color? barrierColor;
+  final SubmitChildBuilder<R>? submitBuilder;
+  final AsyncTaskBuilderController<T, R>? controller;
+
+  const AsyncTaskBuilder._({
+    super.key,
+    required this.mode,
+    required this.task,
+    this.config,
+    this.fetchAtInit = false,
+    this.initBuilder,
+    this.builder,
+    this.onSuccess,
+    this.getFromCache,
+    this.saveToCache,
+    this.barrierColor,
+    this.submitBuilder,
+    this.controller,
+  });
+
+  static AsyncTaskBuilder<void, R> basic<R>({
+    Key? key,
+    required AsyncValueGetter<R> task,
+    FetcherConfig? config,
+    bool fetchAtInit = true,
+    WidgetBuilder? initBuilder,
+    DataWidgetBuilder<R>? builder,
+    ValueSetter<R>? onSuccess,
+    ValueGetter<R?>? getFromCache,
+    ValueChanged<R>? saveToCache,
+    AsyncTaskBuilderController<void, R>? controller,
+  }) {
+    return AsyncTaskBuilder<void, R>._(
+      key: key,
+      mode: AsyncTaskMode.fetch,
+      task: ([_]) => task(),
+      config: config,
+      fetchAtInit: fetchAtInit,
+      initBuilder: initBuilder,
+      builder: builder,
+      onSuccess: onSuccess,
+      getFromCache: getFromCache,
+      saveToCache: saveToCache,
+      controller: controller,
+    );
+  }
+
+  factory AsyncTaskBuilder.fetch({
+    Key? key,
+    required AsyncValueGetter<R> task,
+    FetcherConfig? config,
+    bool fetchAtInit = true,
+    WidgetBuilder? initBuilder,
+    DataWidgetBuilder<R>? builder,
+    ValueSetter<R>? onSuccess,
+    ValueGetter<R?>? getFromCache,
+    ValueChanged<R>? saveToCache,
+    AsyncTaskBuilderController<void, R>? controller,
+  }) {
+    return AsyncTaskBuilder<T, R>._(
+      key: key,
+      mode: AsyncTaskMode.fetch,
+      task: ([_]) => task(),
+      config: config,
+      fetchAtInit: fetchAtInit,
+      initBuilder: initBuilder,
+      builder: builder,
+      onSuccess: onSuccess,
+      getFromCache: getFromCache,
+      saveToCache: saveToCache,
+      controller: controller as AsyncTaskBuilderController<T, R>?,
+    );
+  }
+
+  factory AsyncTaskBuilder.fetchWithParameter({
+    Key? key,
+    required ParameterizedAsyncTask<T, R> task,
+    FetcherConfig? config,
+    bool fetchAtInit = true,
+    WidgetBuilder? initBuilder,
+    DataWidgetBuilder<R>? builder,
+    ValueSetter<R>? onSuccess,
+    ValueGetter<R?>? getFromCache,
+    ValueChanged<R>? saveToCache,
+    AsyncTaskBuilderController<T, R>? controller,
+  }) {
+    return AsyncTaskBuilder<T, R>._(
+      key: key,
+      mode: AsyncTaskMode.fetchWithParameter,
+      task: task,
+      config: config,
+      fetchAtInit: fetchAtInit,
+      initBuilder: initBuilder,
+      builder: builder,
+      onSuccess: onSuccess,
+      getFromCache: getFromCache,
+      saveToCache: saveToCache,
+      controller: controller,
+    );
+  }
+
+  factory AsyncTaskBuilder.submit({
+    Key? key,
+    required AsyncValueGetter<R> task,
+    required SubmitChildBuilder<R> builder,
+    FetcherConfig? config,
+    Color? barrierColor,
+    ValueSetter<R>? onSuccess,
+    AsyncTaskBuilderController<T, R>? controller,
+    bool runTaskOnStart = false,
+  }) {
+    return AsyncTaskBuilder<T, R>._(
+      key: key,
+      mode: AsyncTaskMode.submit,
+      task: ([_]) => task(),
+      config: config,
+      barrierColor: barrierColor,
+      submitBuilder: builder,
+      onSuccess: onSuccess,
+      controller: controller,
+      fetchAtInit: runTaskOnStart,
+    );
+  }
+
+  @override
+  State<AsyncTaskBuilder<T, R>> createState() => _AsyncTaskBuilderState<T, R>();
+}
+
+class _AsyncTaskBuilderState<T, R> extends State<AsyncTaskBuilder<T, R>> {
+  late final FetcherConfig config = DefaultFetcherConfig.of(context).apply(widget.config);
+  EventStream<DataWrapper<R>?>? _stream;
+  bool _isBusy = false;
+  int _lastTaskId = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller?._mountState(this);
+    if (widget.mode != AsyncTaskMode.submit && widget.fetchAtInit) {
+      _initStream();
+      _fetch();
+    }
+  }
+
+  EventStream<DataWrapper<R>?> _initStream() {
+    if (_stream == null) {
+      setState(() {
+        _stream = EventStream<DataWrapper<R>?>();
+      });
+
+      if (widget.getFromCache != null) {
+        try {
+          final cachedData = widget.getFromCache!();
+          if (cachedData != null) {
+            _stream!.add(DataWrapper(cachedData));
+          }
+        } catch (e, s) {
+          config.onError!(e, s);
+        }
+      }
+    }
+    return _stream!;
+  }
+
+  Future<void> _fetch({T? param, bool? clearDataFirst, FetchErrorDisplayMode? errorDisplayMode}) async {
+    final taskId = ++_lastTaskId;
+    if (!mounted) return;
+
+    final stream = _initStream();
+    clearDataFirst ??= stream.hasError;
+    if (clearDataFirst) stream.add(null);
+
+    try {
+      final result = await widget.task(param);
+      if (mounted && taskId == _lastTaskId) {
+        widget.onSuccess?.call(result);
+        widget.saveToCache?.call(result);
+        stream.add(DataWrapper(result));
+      }
+    } catch (e, s) {
+      config.onError!(e, s);
+      if (mounted && taskId == _lastTaskId) {
+        errorDisplayMode ??= FetchErrorDisplayMode.inWidget;
+        final inWidget = errorDisplayMode == FetchErrorDisplayMode.inWidget || stream.valueOrNull == null;
+        final onDisplay = errorDisplayMode == FetchErrorDisplayMode.onDisplay;
+
+        if (inWidget) {
+          stream.addError(FetchException(e, () => _fetch(param: param, errorDisplayMode: FetchErrorDisplayMode.onDisplay)));
+        }
+        if (onDisplay) {
+          config.onDisplayError!(context, e);
+        }
+      }
+    }
+  }
+
+  void _runTask([AsyncValueGetter<R>? task]) async {
+    if (!mounted || _isBusy) return;
+
+    setState(() => _isBusy = true);
+
+    try {
+      final result = await (task ?? (() => widget.task(null)))();
+      if (mounted) widget.onSuccess?.call(result);
+    } catch (e, s) {
+      config.onError?.call(e, s);
+      if (mounted) config.onDisplayError?.call(context, e);
+    }
+
+    if (mounted) setState(() => _isBusy = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    switch (widget.mode) {
+      case AsyncTaskMode.submit:
+        return SubmitBuilder<R>(
+          config: widget.config,
+          barrierColor: widget.barrierColor,
+          runTaskOnStart: widget.fetchAtInit,
+          task: () => widget.task(null),
+          builder: widget.submitBuilder!,
+          onSuccess: widget.onSuccess,
+        );
+
+      case AsyncTaskMode.fetch:
+      case AsyncTaskMode.fetchWithParameter:
+        return EventStreamBuilder<DataWrapper<R>?>(
+          stream: _stream,
+          builder: (context, snapshot) {
+            return FetchBuilderContent<R>(
+              config: config,
+              snapshot: snapshot.data == null
+                  ? AsyncSnapshot<R>.nothing()
+                  : AsyncSnapshot<R>.withData(
+                      snapshot.connectionState,
+                      snapshot.data!.data,
+                    ),
+              initBuilder: widget.initBuilder,
+              builder: widget.builder,
+            );
+          },
+        );
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller?._unmountState(this);
+    _stream?.close();
+    super.dispose();
+  }
+}
+
+class AsyncTaskBuilderController<T, R> {
+  _AsyncTaskBuilderState<T, R>? _state;
+
+  void _mountState(_AsyncTaskBuilderState<T, R> state) => _state = state;
+
+  void _unmountState(_AsyncTaskBuilderState<T, R> state) {
+    if (_state == state) _state = null;
+  }
+
+  Future<void> refresh({T? param, bool? clearDataFirst, FetchErrorDisplayMode? errorDisplayMode}) {
+    return _state?._fetch(param: param, clearDataFirst: clearDataFirst, errorDisplayMode: errorDisplayMode) ?? Future.value();
+  }
+
+  void runTask([AsyncValueGetter<R>? task]) => _state?._runTask(task);
+
+  static AsyncTaskBuilderController<void, R> basic<R>() {
+    return AsyncTaskBuilderController<void, R>();
+  }
+}

--- a/lib/src/fetch_builder.dart
+++ b/lib/src/fetch_builder.dart
@@ -24,9 +24,9 @@ class FetchBuilder<T> extends FetchBuilderWithParameter<Never, T> {
     super.getFromCache,
     super.saveToCache,
   }) : super._(
-    controller: controller,
-    task: (_) => task(),
-  );
+          controller: controller,
+          task: (_) => task(),
+        );
 }
 
 /// A [FetchBuilder] where the refresh method of the controller takes a parameter, passed to [task].
@@ -58,7 +58,7 @@ class FetchBuilderWithParameter<T, R> extends StatefulWidget {
     this.onSuccess,
     this.getFromCache,
     this.saveToCache,
-  // ignore: prefer_initializing_formals    // We force subtype to be used
+    // ignore: prefer_initializing_formals    // We force subtype to be used<<
   }) : controller = controller;
 
   /// Widget configuration, that will override the one provided by [DefaultFetcherConfig]
@@ -141,10 +141,11 @@ class _FetchBuilderWithParameterState<T, R> extends State<FetchBuilderWithParame
   @override
   Widget build(BuildContext context) {
     return EventStreamBuilder<DataWrapper<R>?>(
-      stream: _stream,   // When stream is null, the snapshot's state will be ConnectionState.none.
+      stream: _stream, // When stream is null, the snapshot's state will be ConnectionState.none.
       builder: (context, snapshot) {
         return FetchBuilderContent<DataWrapper<R>?>(
-          config: config,     // Use config from state, not from widget, to force field to be initialized at init. Otherwise, if an error occurs in _fetch while state is unmounted, accessing the config will throw an error because context is unmounted.
+          config:
+              config, // Use config from state, not from widget, to force field to be initialized at init. Otherwise, if an error occurs in _fetch while state is unmounted, accessing the config will throw an error because context is unmounted.
           snapshot: snapshot,
           initBuilder: widget.initBuilder,
           builder: widget.builder == null ? null : (context, data) => widget.builder!.call(context, data!.data),
@@ -175,7 +176,7 @@ class _FetchBuilderWithParameterState<T, R> extends State<FetchBuilderWithParame
     final R result;
     try {
       result = await widget.task(param);
-    } catch(e, s) {
+    } catch (e, s) {
       // Report error first
       config.onError!(e, s);
 
@@ -227,7 +228,7 @@ class _FetchBuilderWithParameterState<T, R> extends State<FetchBuilderWithParame
         stream.add(DataWrapper(result));
         return result;
       }
-    } catch(e, s) {
+    } catch (e, s) {
       config.onError!(e, s);
     }
     return null;

--- a/lib/src/paged_list_view_fetcher.dart
+++ b/lib/src/paged_list_view_fetcher.dart
@@ -1,5 +1,6 @@
 import 'package:fetcher/extra.dart';
 import 'package:fetcher/fetcher.dart';
+import 'package:fetcher/src/fetch_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:value_stream/value_stream.dart';
 


### PR DESCRIPTION
This is a proposal aimed at unifying the usage of fetch and submit operations within a single AsyncTaskBuilder object. It's important to note that this is merely a suggestion for improving code consistency and is open for discussion and refinement.

In particular, the current implementation of `AsyncTaskBuilder<void, T>.submit()` is suboptimal. We should strive to simplify the type parameterization, potentially eliminating the need for the `void` parameter.

Furthermore, it may be beneficial to completely review the architecture to enhance maintainability. This could involve restructuring the AsyncTaskBuilder to better accommodate both fetch and submit operations without unnecessary complexity.

We welcome feedback and alternative ideas from the team to ensure we adopt the most effective and efficient solution for our specific needs.