### PR TITLE
add onTaskSuccess config interceptor

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,6 +21,7 @@ class MyApp extends StatelessWidget {
           content: Text(error.toString()),
           backgroundColor: Colors.red,
         )),
+        onFetchSuccess: (result) => debugPrint('[FetchSuccess] Fetch success with result: $result'),
       ),
       child: MaterialApp(
         title: 'Fetcher Example',

--- a/lib/src/config/default_fetcher_config.dart
+++ b/lib/src/config/default_fetcher_config.dart
@@ -23,7 +23,6 @@ class DefaultFetcherConfig extends InheritedWidget {
     fetchErrorBuilder: (_, data) => FetchBuilderErrorWidget(isDense: data.isDense, onRetry: data.retry),
     onError: (e, s, {reason}) => debugPrint('[Fetcher] onError: $e'),
     onDisplayError: (_, error) => debugPrint('[Fetcher] onDisplayError: $error'),
-    onTaskSuccess: null,
   );
 
   @override

--- a/lib/src/config/default_fetcher_config.dart
+++ b/lib/src/config/default_fetcher_config.dart
@@ -23,6 +23,7 @@ class DefaultFetcherConfig extends InheritedWidget {
     fetchErrorBuilder: (_, data) => FetchBuilderErrorWidget(isDense: data.isDense, onRetry: data.retry),
     onError: (e, s, {reason}) => debugPrint('[Fetcher] onError: $e'),
     onDisplayError: (_, error) => debugPrint('[Fetcher] onDisplayError: $error'),
+    onTaskSuccess: null,
   );
 
   @override

--- a/lib/src/config/fetcher_config.dart
+++ b/lib/src/config/fetcher_config.dart
@@ -13,18 +13,20 @@ class FetcherConfig {
     this.fetchErrorBuilder,
     this.onError,
     this.onDisplayError,
+    this.onTaskSuccess,
   });
 
   /// Fetcher configuration for silent mode.
   /// Use this configuration to hide loader & error.
   FetcherConfig.silent({bool? fade, Duration? fadeDuration}) : this(
-    isDense: true,
-    fadeDuration: fadeDuration,
-    fetchingBuilder: (_) => const SizedBox(),
-    fetchErrorBuilder: (_, __) => const SizedBox(),
-    onError: null,
-    onDisplayError: (_, __) {},
-  );
+          isDense: true,
+          fadeDuration: fadeDuration,
+          fetchingBuilder: (_) => const SizedBox(),
+          fetchErrorBuilder: (_, __) => const SizedBox(),
+          onError: null,
+          onDisplayError: (_, __) {},
+          onTaskSuccess: null,
+        );
 
   /// Whether fetcher is in a low space environment.
   /// Will affect default error widget density.
@@ -55,6 +57,10 @@ class FetcherConfig {
   /// Usually used with a SnackBar system or equivalent.
   final void Function(BuildContext context, Object error)? onDisplayError;
 
+  /// Result interceptor that allows processing successful task results
+  /// Usually used for adding cross-cutting concerns like logging, analytics, or custom behaviors
+  final void Function<T>(T result)? onTaskSuccess;
+
   /// Creates a copy of this config where each fields are overridden by each non-null field of [config].
   FetcherConfig apply(FetcherConfig? config) {
     if (config == null) return this;
@@ -65,6 +71,7 @@ class FetcherConfig {
       fetchErrorBuilder: config.fetchErrorBuilder ?? fetchErrorBuilder,
       onError: config.onError ?? onError,
       onDisplayError: config.onDisplayError ?? onDisplayError,
+      onTaskSuccess: config.onTaskSuccess ?? onTaskSuccess,
     );
   }
 
@@ -77,7 +84,8 @@ class FetcherConfig {
         && other.fetchingBuilder == fetchingBuilder
         && other.fetchErrorBuilder == fetchErrorBuilder
         && other.onError == onError
-        && other.onDisplayError == onDisplayError;
+        && other.onDisplayError == onDisplayError
+        && other.onTaskSuccess == onTaskSuccess;
   }
 
   @override
@@ -87,6 +95,6 @@ class FetcherConfig {
       fetchingBuilder.hashCode ^
       fetchErrorBuilder.hashCode ^
       onError.hashCode ^
-      onDisplayError.hashCode;
+      onDisplayError.hashCode ^
+      onTaskSuccess.hashCode;
 }
-

--- a/lib/src/config/fetcher_config.dart
+++ b/lib/src/config/fetcher_config.dart
@@ -13,20 +13,18 @@ class FetcherConfig {
     this.fetchErrorBuilder,
     this.onError,
     this.onDisplayError,
-    this.onTaskSuccess,
+    this.onFetchSuccess,
   });
 
   /// Fetcher configuration for silent mode.
   /// Use this configuration to hide loader & error.
   FetcherConfig.silent({bool? fade, Duration? fadeDuration}) : this(
-          isDense: true,
-          fadeDuration: fadeDuration,
-          fetchingBuilder: (_) => const SizedBox(),
-          fetchErrorBuilder: (_, __) => const SizedBox(),
-          onError: null,
-          onDisplayError: (_, __) {},
-          onTaskSuccess: null,
-        );
+    isDense: true,
+    fadeDuration: fadeDuration,
+    fetchingBuilder: (_) => const SizedBox(),
+    fetchErrorBuilder: (_, __) => const SizedBox(),
+    onDisplayError: (_, __) {},
+  );
 
   /// Whether fetcher is in a low space environment.
   /// Will affect default error widget density.
@@ -57,9 +55,9 @@ class FetcherConfig {
   /// Usually used with a SnackBar system or equivalent.
   final void Function(BuildContext context, Object error)? onDisplayError;
 
-  /// Result interceptor that allows processing successful task results
-  /// Usually used for adding cross-cutting concerns like logging, analytics, or custom behaviors
-  final void Function<T>(T result)? onTaskSuccess;
+  /// Called when any [FetchBuilder]'s task ends successfully.
+  /// Can be used to add cross-cutting concerns like logging, analytics, or custom behaviors
+  final void Function(dynamic result)? onFetchSuccess;
 
   /// Creates a copy of this config where each fields are overridden by each non-null field of [config].
   FetcherConfig apply(FetcherConfig? config) {
@@ -71,7 +69,7 @@ class FetcherConfig {
       fetchErrorBuilder: config.fetchErrorBuilder ?? fetchErrorBuilder,
       onError: config.onError ?? onError,
       onDisplayError: config.onDisplayError ?? onDisplayError,
-      onTaskSuccess: config.onTaskSuccess ?? onTaskSuccess,
+      onFetchSuccess: config.onFetchSuccess ?? onFetchSuccess,
     );
   }
 
@@ -85,7 +83,7 @@ class FetcherConfig {
         && other.fetchErrorBuilder == fetchErrorBuilder
         && other.onError == onError
         && other.onDisplayError == onDisplayError
-        && other.onTaskSuccess == onTaskSuccess;
+        && other.onFetchSuccess == onFetchSuccess;
   }
 
   @override
@@ -96,5 +94,5 @@ class FetcherConfig {
       fetchErrorBuilder.hashCode ^
       onError.hashCode ^
       onDisplayError.hashCode ^
-      onTaskSuccess.hashCode;
+      onFetchSuccess.hashCode;
 }

--- a/lib/src/fetch_builder.dart
+++ b/lib/src/fetch_builder.dart
@@ -24,9 +24,9 @@ class FetchBuilder<T> extends FetchBuilderWithParameter<Never, T> {
     super.builder,
     super.onSuccess,
   }) : super._(
-    controller: controller,
-    task: (_) => task(),
-  );
+          controller: controller,
+          task: (_) => task(),
+        );
 }
 
 /// A [FetchBuilder] where the refresh method of the controller takes a parameter, passed to [task].
@@ -54,7 +54,7 @@ class FetchBuilderWithParameter<T, R> extends StatefulWidget {
     this.initBuilder,
     this.builder,
     this.onSuccess,
-  // ignore: prefer_initializing_formals    // We force subtype to be used
+    // ignore: prefer_initializing_formals    // We force subtype to be used
   }) : controller = controller;
 
   /// Widget configuration, that will override the one provided by [DefaultFetcherConfig]
@@ -168,6 +168,9 @@ class _FetchBuilderWithParameterState<T, R> extends State<FetchBuilderWithParame
 
       // If task is still valid
       if (isTaskValid()) {
+        // Intercept result if configured
+        config.onTaskSuccess?.call(result);
+
         // Call onSuccess
         widget.onSuccess?.call(result);
 

--- a/lib/src/fetch_builder.dart
+++ b/lib/src/fetch_builder.dart
@@ -24,9 +24,9 @@ class FetchBuilder<T> extends FetchBuilderWithParameter<Never, T> {
     super.builder,
     super.onSuccess,
   }) : super._(
-          controller: controller,
-          task: (_) => task(),
-        );
+    controller: controller,
+    task: (_) => task(),
+  );
 }
 
 /// A [FetchBuilder] where the refresh method of the controller takes a parameter, passed to [task].
@@ -168,8 +168,8 @@ class _FetchBuilderWithParameterState<T, R> extends State<FetchBuilderWithParame
 
       // If task is still valid
       if (isTaskValid()) {
-        // Intercept result if configured
-        config.onTaskSuccess?.call(result);
+        // Call config onFetchSuccess
+        config.onFetchSuccess?.call(result);
 
         // Call onSuccess
         widget.onSuccess?.call(result);


### PR DESCRIPTION
This PR introduces a new configuration option `onTaskSuccess` in `FetcherConfig` that allows intercepting successful task results globally. This is particularly useful for implementing cross-cutting concerns like analytics, logging, or monitoring without modifying individual widgets.

- Added `onTaskSuccess` callback to `FetcherConfig`
- Implemented result interception in `FetchBuilder` after task completion
- Kept existing `onSuccess` behavior for local widget-specific actions

## Example Usage
```dart
DefaultFetcherConfig(
  config: FetcherConfig(
    onTaskSuccess: <T>(T result) {
      // Handle any successful result globally
      // e.g., analytics, logging, monitoring
    },
    // ... other config
  ),
  child: MyApp(),
)
```

## Benefits
- Removes the need for wrapper widgets (like custom tracking widgets)
- Provides a clean separation between cross-cutting concerns and business logic
- Maintains consistent behavior across the application

## Breaking Changes
None. This is a non-breaking addition to the existing configuration.